### PR TITLE
Fixed server not fetching posts with text only. 

### DIFF
--- a/application/server/controller/post-controller.js
+++ b/application/server/controller/post-controller.js
@@ -129,8 +129,8 @@ module.exports = {
       order: [["date_time", "DESC"]],
       limit: 60,
       include: [
-        { model: Text },
-        { model: Media },
+        { model: Text, required: true },
+        { model: Media, required: false },
         {
           model: User,
           attributes: ["user_id", "username", "user_handle"],


### PR DESCRIPTION
Added 'required: true' to the model Text in the database fetch query. Apparently, text should always be required to make everything function as it currently is. #26 